### PR TITLE
Allow enemies to be shot, and tank to be hit.

### DIFF
--- a/src/IGE.TankShooter.Entry/Game1.cs
+++ b/src/IGE.TankShooter.Entry/Game1.cs
@@ -34,6 +34,9 @@ public class Game1 : Game
   private CollisionComponent CollisionComponent;
   private CameraOperator CameraOperator;
 
+  private int EnemiesRemaining = 5;
+  private int Points = 0;
+
   public OrthographicCamera Camera { get; set; }
 
   public Game1()
@@ -59,6 +62,8 @@ public class Game1 : Game
     
     this.tank = new Tank(this, this.Background.BoundingBox.Center);
     this.tank.Initialize();
+    
+    CollisionComponent.Insert(this.tank);
 
     var ratio = this.graphics.PreferredBackBufferWidth / 100;
 
@@ -134,16 +139,19 @@ public class Game1 : Game
 
   private void MaybeSpawnEnemy(GameTime gameTime)
   {
-    if (this.EnemySpawnTimer.Update(gameTime))
+    if (EnemiesRemaining <= 0 || !this.EnemySpawnTimer.Update(gameTime))
     {
-      var random = new Random();
-      // Project outward from the tank a distance of 50-75m and then rotate randomly in a 360 degree arc.
-      var distanceFromTank = random.NextSingle(50f, 75f);
-      var spawnPosition = this.tank.CurrentPosition + (Vector2.One * distanceFromTank).Rotate((float)(new Random().NextDouble() * Math.PI));
-      var enemy = new Enemy(spawnPosition, this.EnemyPersonTextures[random.Next(0, this.EnemyPersonTextures.Length)], this.tank);
-      Enemies.Add(enemy);
-      CollisionComponent.Insert(enemy);
+      return;
     }
+    
+    var random = new Random();
+    // Project outward from the tank a distance of 50-75m and then rotate randomly in a 360 degree arc.
+    var distanceFromTank = random.NextSingle(50f, 75f);
+    var spawnPosition = this.tank.CurrentPosition + (Vector2.One * distanceFromTank).Rotate((float)(new Random().NextDouble() * Math.PI));
+    var enemy = new Enemy(spawnPosition, this.EnemyPersonTextures[random.Next(0, this.EnemyPersonTextures.Length)], this.tank);
+    Enemies.Add(enemy);
+    CollisionComponent.Insert(enemy);
+    EnemiesRemaining--;
   }
 
   protected override void Draw(GameTime gameTime)
@@ -196,5 +204,18 @@ public class Game1 : Game
     CollisionComponent.Remove(enemy);
     
     RemoveBullet(bullet);
+    Points += 1000;
+
+    if (Enemies.Count == 0)
+    {
+      Console.WriteLine("All enemies dead");
+    }
   }
+
+  public void OnPlayerHit(Enemy enemy)
+  {
+    Enemies.Remove(enemy);
+    CollisionComponent.Remove(enemy);
+  }
+  
 }

--- a/src/IGE.TankShooter.Entry/GameObjects/Enemy.cs
+++ b/src/IGE.TankShooter.Entry/GameObjects/Enemy.cs
@@ -50,7 +50,6 @@ public class Enemy : GameObject, ICollisionActor
 
   public void OnCollision(CollisionEventArgs collisionInfo)
   {
-    
   }
 
   public IShapeF Bounds { get; }


### PR DESCRIPTION
Shooting enemies doesn't do much more than increment a points counter (which is not used anywhere) and remove the enemy.

This does limit the number of enemies. Using a low number of 5 for now just for testing, so that we can start to toy with what happens when all enemies are cleared.

Hitting the player is crude, because the collision bounds are a circle which only approximate the size of the tank, and in practice is a bit bigger. It therefore doesn't take into account tank rotations.

Players hitting the tank doesn't cause any kind of damage as of yet, but rather just makes the enemy get removed.