### PR TITLE
More specific debug line control.

### DIFF
--- a/src/IGE.TankShooter.Entry/Core/Debug.cs
+++ b/src/IGE.TankShooter.Entry/Core/Debug.cs
@@ -3,8 +3,20 @@
 public class Debug
 {
   /// <summary>
-  /// Helper method to draw additional debug information over game objects.
-  /// Up to individual game objects to decide what to do with this information.
+  /// Helper to draw additional debug information over game objects.
   /// </summary>
-  public const bool DrawDebugLines = true;
+  public static class DrawDebugLines {
+
+    public static class Collisions {
+      public static bool Bounds = true;
+    }
+
+    public static class Pathfinding {
+      public static bool Grid = false;
+      public static bool Results = true;
+    }
+
+    public static bool Movement = true;
+
+  }
 }

--- a/src/IGE.TankShooter.Entry/Core/Pathfinder.cs
+++ b/src/IGE.TankShooter.Entry/Core/Pathfinder.cs
@@ -264,7 +264,7 @@ public class Pathfinder
 
   public void Draw(SpriteBatch spriteBatch)
   {
-    if (_pathfindingGraph == null || !Debug.DrawDebugLines)
+    if (_pathfindingGraph == null || !Debug.DrawDebugLines.Pathfinding.Grid)
     {
       return;
     }
@@ -387,7 +387,6 @@ public class NavigationPath
     // figure out the closest. If we are exactly on top of a vertex, then
     // advance to the next one and return that.
 
-    // TODO: Expensive to create a list each time.
     foreach (var edge in _path)
     {
       if (edge.Target == currentVertex)
@@ -412,7 +411,7 @@ public class NavigationPath
 
   public void Draw(SpriteBatch spriteBatch)
   {
-    if (Debug.DrawDebugLines)
+    if (Debug.DrawDebugLines.Pathfinding.Grid && Debug.DrawDebugLines.Pathfinding.Results)
     { 
       foreach (var edge in ExaminedEdges) {
         var source = _pathfinder.PathfindingGridVertexToWorld(edge.Source);
@@ -427,7 +426,10 @@ public class NavigationPath
           0.1f
         );
       }
-      
+    }
+
+    if (Debug.DrawDebugLines.Pathfinding.Results)
+    { 
       if (Path != null)
       {
         foreach (var edge in Path) {

--- a/src/IGE.TankShooter.Entry/Game1.cs
+++ b/src/IGE.TankShooter.Entry/Game1.cs
@@ -119,6 +119,8 @@ public class Game1 : Game
     if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
       Exit();
 
+    ToggleDebugInfo();
+
     MaybeFireBullet();
     MaybeSpawnEnemy(gameTime);
     
@@ -138,6 +140,36 @@ public class Game1 : Game
     CollisionComponent.Update(gameTime);
 
     base.Update(gameTime);
+  }
+
+  private void ToggleDebugInfo()
+  {
+    var kb = KeyboardExtended.GetState();
+    if (!kb.IsShiftDown())
+    {
+        return;
+    }
+
+    if (kb.WasKeyJustDown(Keys.M))
+    {
+      Debug.DrawDebugLines.Movement = !Debug.DrawDebugLines.Movement;
+    }
+
+    if (kb.WasKeyJustDown(Keys.G))
+    {
+      Debug.DrawDebugLines.Pathfinding.Grid = !Debug.DrawDebugLines.Pathfinding.Grid;
+    }
+
+    if (kb.WasKeyJustDown(Keys.P))
+    {
+      Debug.DrawDebugLines.Pathfinding.Results = !Debug.DrawDebugLines.Pathfinding.Results;
+    }
+    
+    if (kb.WasKeyJustDown(Keys.C))
+    {
+      Debug.DrawDebugLines.Collisions.Bounds = !Debug.DrawDebugLines.Collisions.Bounds;
+    }
+    
   }
 
   private void MaybeFireBullet()

--- a/src/IGE.TankShooter.Entry/GameObjects/Bullet.cs
+++ b/src/IGE.TankShooter.Entry/GameObjects/Bullet.cs
@@ -36,7 +36,7 @@ public class Bullet : GameObject, ICollisionActor
   {
     Sprite.Draw(spriteBatch, this.Bounds.Position, Velocity.ToAngle(), SpriteScale);
 
-    if (Debug.DrawDebugLines)
+    if (Debug.DrawDebugLines.Collisions.Bounds)
     {
       spriteBatch.DrawCircle((CircleF)this.Bounds, 10, Color.Black, 0.1f);
       spriteBatch.DrawLine(this.initialPosition, this.initialPosition + this.Velocity, Color.Yellow, 0.1f);

--- a/src/IGE.TankShooter.Entry/GameObjects/Enemy.cs
+++ b/src/IGE.TankShooter.Entry/GameObjects/Enemy.cs
@@ -72,7 +72,7 @@ public class Enemy : GameObject, ICollisionActor
 
     spriteBatch.Draw(Sprite, this.Bounds.Position, this.Direction.ToAngle() + (float)Math.PI / 2f, new Vector2(SIZE / Texture.Width));
 
-    if (Debug.DrawDebugLines)
+    if (Debug.DrawDebugLines.Collisions.Bounds)
     {
       spriteBatch.DrawCircle((CircleF)this.Bounds, 10, Color.Red, 0.2f);
       spriteBatch.DrawLine(this.Bounds.Position, this.Bounds.Position + (this.Direction * 5), Color.Red, 0.2f);

--- a/src/IGE.TankShooter.Entry/GameObjects/Tank.cs
+++ b/src/IGE.TankShooter.Entry/GameObjects/Tank.cs
@@ -141,9 +141,13 @@ public class Tank : GameObject, ICollisionActor
   {
     spriteBatch.Draw(Sprite, Transform);
 
-    if (Debug.DrawDebugLines)
+    if (Debug.DrawDebugLines.Collisions.Bounds)
     {
       spriteBatch.DrawCircle(this.bounds, 15, Color.Cyan, 0.1f);
+    }
+
+    if (Debug.DrawDebugLines.Movement)
+    {
       spriteBatch.DrawLine(CurrentPosition, CurrentPosition + velocity.TargetDirection * 10, Color.Cyan, 0.2f);
       spriteBatch.DrawLine(CurrentPosition, CurrentPosition + (velocity.Direction).NormalizedCopy() * 10, Color.LightCyan, 0.2f);
     }
@@ -308,7 +312,7 @@ class Turret : GameObject
   {
     spriteBatch.Draw(Sprite, Transform);
 
-    if (Debug.DrawDebugLines)
+    if (Debug.DrawDebugLines.Movement)
     {
       spriteBatch.DrawCircle(this.CurrentBarrelTipPosition, 0.5f, 8, Color.Cyan, 0.1f);
     }

--- a/src/IGE.TankShooter.Entry/Graphics/BackgroundMap.cs
+++ b/src/IGE.TankShooter.Entry/Graphics/BackgroundMap.cs
@@ -131,7 +131,7 @@ public class BackgroundMap
   {
     spriteBatch.Draw(_sprite, _transform);
 
-    if (Debug.DrawDebugLines)
+    if (Debug.DrawDebugLines.Collisions.Bounds)
     {
       foreach (var target in GetCollisionTargets())
       {


### PR DESCRIPTION
Don't always draw all debug lines. Only specific types of lines at specific times. Allow certain debug info to be shown/hidden by:

 * Shift + M: Movement direction lines.
 * Shift + C: Collision bounds.
 * Shift + G: Pathfinding grid.
 * Shift + P: Pathfinding results.

If G + P are both enabled, then the parts of the pathfinding grid which were searched in order to find the resulting path are also shown.