### PR TITLE
Add red particle's to enemies after they get hit

### DIFF
--- a/src/IGE.TankShooter.Entry/Core/Debug.cs
+++ b/src/IGE.TankShooter.Entry/Core/Debug.cs
@@ -8,15 +8,15 @@ public class Debug
   public static class DrawDebugLines {
 
     public static class Collisions {
-      public static bool Bounds = true;
+      public static bool Bounds = false;
     }
 
     public static class Pathfinding {
       public static bool Grid = false;
-      public static bool Results = true;
+      public static bool Results = false;
     }
 
-    public static bool Movement = true;
+    public static bool Movement = false;
 
   }
 }

--- a/src/IGE.TankShooter.Entry/GameObjects/Bullet.cs
+++ b/src/IGE.TankShooter.Entry/GameObjects/Bullet.cs
@@ -15,7 +15,7 @@ public class Bullet : GameObject, ICollisionActor
 
   private readonly Game1 tankGame;
   public IShapeF Bounds { get; }
-  private Vector2 Velocity { get; }
+  public Vector2 Velocity { get; }
   private readonly Sprite Sprite;
   private readonly Vector2 SpriteScale;
   

--- a/src/IGE.TankShooter.Entry/IGE.TankShooter.Entry.csproj
+++ b/src/IGE.TankShooter.Entry/IGE.TankShooter.Entry.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="MonoGame.Extended.Collisions" Version="3.9.0-alpha0093" />
     <PackageReference Include="MonoGame.Extended.Graphics" Version="3.9.0-alpha0093" />
     <PackageReference Include="MonoGame.Extended.Input" Version="3.9.0-alpha0093" />
+    <PackageReference Include="MonoGame.Extended.Particles" Version="3.8.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended.Tiled" Version="3.9.0-alpha0093" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-alpha0093" />


### PR DESCRIPTION
Simulates a blast of blood in the direction of the tanks bullet. In the future, would need to change based on the type of bullet (if bullet changes are supported at some point). Would also need to change the type of particle from red (blood) to shrapnel or other types depending on the enemy type (e.g. drones or robots of some sort).

As with most things, this is sort of a proof of concept, hard coded as such at this point.